### PR TITLE
Fix flutter run error on android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ app.*.symbols
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock
+.fvmrc

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.9.20'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip

--- a/lib/design_patterns/command/commands/change_color_command.dart
+++ b/lib/design_patterns/command/commands/change_color_command.dart
@@ -1,4 +1,4 @@
-import 'package:faker/faker.dart';
+import 'package:faker/faker.dart' as faker;
 import 'package:flutter/material.dart';
 
 import '../command.dart';
@@ -15,9 +15,9 @@ class ChangeColorCommand implements Command {
 
   @override
   void execute() => shape.color = Color.fromRGBO(
-        random.integer(255),
-        random.integer(255),
-        random.integer(255),
+        faker.random.integer(255),
+        faker.random.integer(255),
+        faker.random.integer(255),
         1.0,
       );
 

--- a/lib/design_patterns/memento/command_design_pattern/commands/randomise_properties_command.dart
+++ b/lib/design_patterns/memento/command_design_pattern/commands/randomise_properties_command.dart
@@ -1,4 +1,4 @@
-import 'package:faker/faker.dart';
+import 'package:faker/faker.dart' as faker;
 import 'package:flutter/material.dart';
 
 import '../../memento/imemento.dart';
@@ -17,13 +17,13 @@ class RandomisePropertiesCommand implements ICommand {
     final shape = originator.state;
 
     shape.color = Color.fromRGBO(
-      random.integer(255),
-      random.integer(255),
-      random.integer(255),
+      faker.random.integer(255),
+      faker.random.integer(255),
+      faker.random.integer(255),
       1.0,
     );
-    shape.height = random.integer(150, min: 50).toDouble();
-    shape.width = random.integer(150, min: 50).toDouble();
+    shape.height = faker.random.integer(150, min: 50).toDouble();
+    shape.width = faker.random.integer(150, min: 50).toDouble();
   }
 
   @override

--- a/lib/design_patterns/prototype/shapes/circle.dart
+++ b/lib/design_patterns/prototype/shapes/circle.dart
@@ -1,4 +1,4 @@
-import 'package:faker/faker.dart';
+import 'package:faker/faker.dart' as faker;
 import 'package:flutter/material.dart';
 
 import '../shape.dart';
@@ -20,12 +20,12 @@ class Circle extends Shape {
   @override
   void randomiseProperties() {
     color = Color.fromRGBO(
-      random.integer(255),
-      random.integer(255),
-      random.integer(255),
+      faker.random.integer(255),
+      faker.random.integer(255),
+      faker.random.integer(255),
       1.0,
     );
-    radius = random.integer(50, min: 25).toDouble();
+    radius = faker.random.integer(50, min: 25).toDouble();
   }
 
   @override

--- a/lib/design_patterns/prototype/shapes/rectangle.dart
+++ b/lib/design_patterns/prototype/shapes/rectangle.dart
@@ -1,4 +1,4 @@
-import 'package:faker/faker.dart';
+import 'package:faker/faker.dart' as faker;
 import 'package:flutter/material.dart';
 
 import '../shape.dart';
@@ -24,13 +24,13 @@ class Rectangle extends Shape {
   @override
   void randomiseProperties() {
     color = Color.fromRGBO(
-      random.integer(255),
-      random.integer(255),
-      random.integer(255),
+      faker.random.integer(255),
+      faker.random.integer(255),
+      faker.random.integer(255),
       1.0,
     );
-    height = random.integer(100, min: 50).toDouble();
-    width = random.integer(100, min: 50).toDouble();
+    height = faker.random.integer(100, min: 50).toDouble();
+    width = faker.random.integer(100, min: 50).toDouble();
   }
 
   @override


### PR DESCRIPTION
using flutter 3.13.0 with java 11.0.23

setting alias to faker package when used with material package to avoid some conflicts by ambiguous names like Color class

setting up compatible versions among  Kotlin, AGP and Gradle.

----
java version "11.0.23" 2024-04-16 LTS
Java(TM) SE Runtime Environment 18.9 (build 11.0.23+7-LTS-222)
Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11.0.23+7-LTS-222, mixed mode)
Flutter 3.13.0 • channel stable • https://github.com/flutter/flutter.git
Framework • revision efbf63d9c6 (1 year, 1 month ago) • 2023-08-15 21:05:06 -0500
Engine • revision 1ac611c64e
Tools • Dart 3.1.0 • DevTools 2.25.0